### PR TITLE
Update fabric version to 1.2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: go
 go:
-  - "1.9"
+  - "1.10.4"
 
 env:
-  - HLF_VERSION="1.1.0"
+  - HLF_VERSION="1.2.1"
 
 # whitelist (branches that should be built)
 branches:


### PR DESCRIPTION
Update travis builds to match the default version of Fabric used in build-lib scripts

Contributes to IBM-Blockchain-Starter-Kit/build-lib#78

Signed-off-by: James Taylor <jamest@uk.ibm.com>